### PR TITLE
T/1: Initial implementation of Highlight editing without UI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
     "ckeditor5-feature"
   ],
   "dependencies": {
+    "@ckeditor/ckeditor5-core": "^1.0.0-alpha.1",
+    "@ckeditor/ckeditor5-engine": "^1.0.0-alpha.1",
+    "@ckeditor/ckeditor5-ui": "^1.0.0-alpha.1"
   },
   "devDependencies": {
+    "@ckeditor/ckeditor5-paragraph": "^1.0.0-alpha.1",
     "eslint": "^4.8.0",
     "eslint-config-ckeditor5": "^1.0.6",
     "husky": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,13 @@
     "@ckeditor/ckeditor5-ui": "^1.0.0-alpha.1"
   },
   "devDependencies": {
+    "@ckeditor/ckeditor5-block-quote": "^1.0.0-alpha.1",
+    "@ckeditor/ckeditor5-enter": "^1.0.0-alpha.1",
+    "@ckeditor/ckeditor5-heading": "^1.0.0-alpha.1",
+    "@ckeditor/ckeditor5-image": "^1.0.0-alpha.1",
+    "@ckeditor/ckeditor5-list": "^1.0.0-alpha.1",
     "@ckeditor/ckeditor5-paragraph": "^1.0.0-alpha.1",
+    "@ckeditor/ckeditor5-typing": "^1.0.0-alpha.1",
     "eslint": "^4.8.0",
     "eslint-config-ckeditor5": "^1.0.6",
     "husky": "^0.14.3",

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -1,0 +1,36 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module highlight/highlight
+ */
+
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+
+import HighlightEditing from './highlightediting';
+import HighlightUI from './highlightui';
+
+/**
+ * The highlight plugin.
+ *
+ * It requires {@link module:highlight/highlightediting~HighlightEditing} and {@link module:highlight/highlightui~HighlightUI} plugins.
+ *
+ * @extends module:core/plugin~Plugin
+ */
+export default class Highlight extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	static get requires() {
+		return [ HighlightEditing, HighlightUI ];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	static get pluginName() {
+		return 'Highlight';
+	}
+}

--- a/src/highlightcommand.js
+++ b/src/highlightcommand.js
@@ -10,7 +10,7 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 /**
- * The highlight command. It is used by the {@link module:highlight/highlight~HighlightEditing highlight feature}
+ * The highlight command. It is used by the {@link module:highlight/highlightediting~HighlightEditing highlight feature}
  * to apply text highlighting.
  *
  * @extends module:core/command~Command
@@ -64,5 +64,5 @@ export default class HighlightCommand extends Command {
  *
  * @observable
  * @readonly
- * @member {undefined|String} HighlightCommand#value
+ * @member {undefined|String} module:highlight/highlightcommand~HighlightCommand#value
  */

--- a/src/highlightcommand.js
+++ b/src/highlightcommand.js
@@ -1,0 +1,91 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module highlight/highlightcommand
+ */
+
+import Command from '@ckeditor/ckeditor5-core/src/command';
+
+/**
+ * The highlight command.
+ *
+ * @extends module:core/command~Command
+ */
+export default class HighlightCommand extends Command {
+	/**
+	 * Creates an instance of the command.
+	 *
+	 * @param {module:core/editor/editor~Editor} editor The editor instance.
+	 * @param {'left'|'right'|'center'|'justify'} type Highlight type to be handled by this command.
+	 */
+	constructor( editor, type ) {
+		super( editor );
+
+		/**
+		 * The type of the list created by the command.
+		 *
+		 * @readonly
+		 * @member {'left'|'right'|'center'|'justify'}
+		 */
+		this.type = type;
+
+		/**
+		 * A flag indicating whether the command is active, which means that the selection starts in a block
+		 * that has defined highlight of the same type.
+		 *
+		 * @observable
+		 * @readonly
+		 * @member {Boolean} #value
+		 */
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	refresh() {
+		this.isEnabled = this._checkEnabled();
+		this.value = this._getValue();
+	}
+
+	/**
+	 * Executes the command.
+	 *
+	 * @protected
+	 * @param {Object} [options] Options for the executed command.
+	 * @param {module:engine/model/batch~Batch} [options.batch] A batch to collect all the change steps.
+	 * A new batch will be created if this option is not set.
+	 */
+	execute() {
+		const editor = this.editor;
+		const document = editor.document;
+
+		document.enqueueChanges( () => {
+			// TODO
+		} );
+	}
+
+	/**
+	 * Checks whether the command can be enabled in the current context.
+	 *
+	 * @private
+	 * @param {module:engine/model/element~Element} firstBlock A first block in selection to be checked.
+	 * @returns {Boolean} Whether the command should be enabled.
+	 */
+	_checkEnabled() {
+		return true;
+	}
+
+	/**
+	 * Checks the command's {@link #value}.
+	 *
+	 * @private
+	 * @param {module:engine/model/element~Element} firstBlock A first block in selection to be checked.
+	 * @returns {Boolean} The current value.
+	 */
+	_getValue() {
+		return true;
+	}
+}

--- a/src/highlightcommand.js
+++ b/src/highlightcommand.js
@@ -66,23 +66,19 @@ export default class HighlightCommand extends Command {
 		const selection = doc.selection;
 		const value = options.class;
 
-		doc.enqueueChanges( () => {
-			if ( selection.isCollapsed ) {
-				if ( value ) {
-					selection.setAttribute( 'highlight', value );
-				} else {
-					selection.removeAttribute( 'highlight' );
-				}
-			} else {
-				const ranges = doc.schema.getValidRanges( selection.getRanges(), 'highlight' );
-				const batch = options.batch || doc.batch();
+		if ( selection.isCollapsed ) {
+			return;
+		}
 
-				for ( const range of ranges ) {
-					if ( value ) {
-						batch.setAttribute( range, 'highlight', value );
-					} else {
-						batch.removeAttribute( range, 'highlight' );
-					}
+		doc.enqueueChanges( () => {
+			const ranges = doc.schema.getValidRanges( selection.getRanges(), 'highlight' );
+			const batch = options.batch || doc.batch();
+
+			for ( const range of ranges ) {
+				if ( value ) {
+					batch.setAttribute( range, 'highlight', value );
+				} else {
+					batch.removeAttribute( range, 'highlight' );
 				}
 			}
 		} );

--- a/src/highlightcommand.js
+++ b/src/highlightcommand.js
@@ -57,15 +57,34 @@ export default class HighlightCommand extends Command {
 	 *
 	 * @protected
 	 * @param {Object} [options] Options for the executed command.
+	 * @param {String} options.class Name of marker class name.
 	 * @param {module:engine/model/batch~Batch} [options.batch] A batch to collect all the change steps.
 	 * A new batch will be created if this option is not set.
 	 */
-	execute() {
-		const editor = this.editor;
-		const document = editor.document;
+	execute( options = {} ) {
+		const doc = this.editor.document;
+		const selection = doc.selection;
+		const value = options.class;
 
-		document.enqueueChanges( () => {
-			// TODO
+		doc.enqueueChanges( () => {
+			if ( selection.isCollapsed ) {
+				if ( value ) {
+					selection.setAttribute( 'highlight', value );
+				} else {
+					selection.removeAttribute( 'highlight' );
+				}
+			} else {
+				const ranges = doc.schema.getValidRanges( selection.getRanges(), 'highlight' );
+				const batch = options.batch || doc.batch();
+
+				for ( const range of ranges ) {
+					if ( value ) {
+						batch.setAttribute( range, 'highlight', value );
+					} else {
+						batch.removeAttribute( range, 'highlight' );
+					}
+				}
+			}
 		} );
 	}
 }

--- a/src/highlightcommand.js
+++ b/src/highlightcommand.js
@@ -46,8 +46,10 @@ export default class HighlightCommand extends Command {
 	 * @inheritDoc
 	 */
 	refresh() {
-		this.isEnabled = this._checkEnabled();
-		this.value = this._getValue();
+		const doc = this.editor.document;
+
+		this.value = doc.selection.getAttribute( 'highlight' );
+		this.isEnabled = doc.schema.checkAttributeInSelection( doc.selection, 'highlight' );
 	}
 
 	/**
@@ -65,27 +67,5 @@ export default class HighlightCommand extends Command {
 		document.enqueueChanges( () => {
 			// TODO
 		} );
-	}
-
-	/**
-	 * Checks whether the command can be enabled in the current context.
-	 *
-	 * @private
-	 * @param {module:engine/model/element~Element} firstBlock A first block in selection to be checked.
-	 * @returns {Boolean} Whether the command should be enabled.
-	 */
-	_checkEnabled() {
-		return true;
-	}
-
-	/**
-	 * Checks the command's {@link #value}.
-	 *
-	 * @private
-	 * @param {module:engine/model/element~Element} firstBlock A first block in selection to be checked.
-	 * @returns {Boolean} The current value.
-	 */
-	_getValue() {
-		return true;
 	}
 }

--- a/src/highlightcommand.js
+++ b/src/highlightcommand.js
@@ -10,38 +10,12 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 /**
- * The highlight command.
+ * The highlight command. It is used by the {@link module:highlight/highlight~HighlightEditing highlight feature}
+ * to apply text highlighting.
  *
  * @extends module:core/command~Command
  */
 export default class HighlightCommand extends Command {
-	/**
-	 * Creates an instance of the command.
-	 *
-	 * @param {module:core/editor/editor~Editor} editor The editor instance.
-	 * @param {'left'|'right'|'center'|'justify'} type Highlight type to be handled by this command.
-	 */
-	constructor( editor, type ) {
-		super( editor );
-
-		/**
-		 * The type of the list created by the command.
-		 *
-		 * @readonly
-		 * @member {'left'|'right'|'center'|'justify'}
-		 */
-		this.type = type;
-
-		/**
-		 * A flag indicating whether the command is active, which means that the selection starts in a block
-		 * that has defined highlight of the same type.
-		 *
-		 * @observable
-		 * @readonly
-		 * @member {Boolean} #value
-		 */
-	}
-
 	/**
 	 * @inheritDoc
 	 */
@@ -57,15 +31,15 @@ export default class HighlightCommand extends Command {
 	 *
 	 * @protected
 	 * @param {Object} [options] Options for the executed command.
-	 * @param {String} options.class Name of marker class name.
+	 * @param {String} options.class Name of highlighter class.
 	 * @param {module:engine/model/batch~Batch} [options.batch] A batch to collect all the change steps.
 	 * A new batch will be created if this option is not set.
 	 */
 	execute( options = {} ) {
 		const doc = this.editor.document;
 		const selection = doc.selection;
-		const value = options.class;
 
+		// Do not apply highlight no collapsed selection.
 		if ( selection.isCollapsed ) {
 			return;
 		}
@@ -75,8 +49,8 @@ export default class HighlightCommand extends Command {
 			const batch = options.batch || doc.batch();
 
 			for ( const range of ranges ) {
-				if ( value ) {
-					batch.setAttribute( range, 'highlight', value );
+				if ( options.class ) {
+					batch.setAttribute( range, 'highlight', options.class );
 				} else {
 					batch.removeAttribute( range, 'highlight' );
 				}
@@ -84,3 +58,11 @@ export default class HighlightCommand extends Command {
 		} );
 	}
 }
+
+/**
+ * Holds current highlight class. If there is no highlight in selection then value will be undefined.
+ *
+ * @observable
+ * @readonly
+ * @member {undefined|String} HighlightCommand#value
+ */

--- a/src/highlightediting.js
+++ b/src/highlightediting.js
@@ -65,17 +65,11 @@ export default class HighlightEditing extends Plugin {
 			.toAttribute( viewElement => {
 				const viewClassNames = [ ...viewElement.getClassNames() ];
 
-				if ( !viewClassNames.length ) {
-					return;
+				for ( const className of viewClassNames ) {
+					if ( configuredClasses.indexOf( className ) > -1 ) {
+						return { key: 'highlight', value: className };
+					}
 				}
-
-				const highlightClassNames = viewClassNames.filter( className => configuredClasses.includes( className ) );
-
-				if ( !highlightClassNames.length ) {
-					return;
-				}
-
-				return { key: 'highlight', value: highlightClassNames[ 0 ] };
 			} );
 
 		editor.commands.add( 'highlight', new HighlightCommand( editor ) );

--- a/src/highlightediting.js
+++ b/src/highlightediting.js
@@ -9,13 +9,16 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
-import HighlightCommand from './highlightcommand';
 import buildViewConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildviewconverter';
 import buildModelConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildmodelconverter';
 
 import AttributeElement from '@ckeditor/ckeditor5-engine/src/view/attributeelement';
 
+import HighlightCommand from './highlightcommand';
+
 /**
+ * The highlight editing feature. It introduces `highlight` command which allow to highlight selected text with defined 'marker' or 'pen'.
+ *
  * @extends module:core/plugin~Plugin
  */
 export default class HighlightEditing extends Plugin {
@@ -69,3 +72,50 @@ export default class HighlightEditing extends Plugin {
 		editor.commands.add( 'highlight', new HighlightCommand( editor ) );
 	}
 }
+
+/**
+ * Highlight option descriptor.
+ *
+ * @typedef {Object} module:highlight/highlightediting~HeadingOption
+ * @property {String} class The class which is used to differentiate highlighters.
+ * @property {String} title The user-readable title of the option.
+ * @property {String} color Color used for highlighter. Should be coherent with CSS class definition.
+ * @property {'marker'|'pen'} type The type of highlighter. Either "marker" - will use #color as background name
+ * of the view element that will be used to represent the model element in the view.
+ */
+
+/**
+ * The configuration of the {@link module:highlight/highlightediting~HighlightEditing Highlight feature}.
+ *
+ * Read more in {@link module:highlight/highlightediting~HighlightEditingConfig}.
+ *
+ * @member {module:highlight/highlightediting~HighlightEditingConfig} module:core/editor/editorconfig~EditorConfig#alignment
+ */
+
+/**
+ * The configuration of the {@link module:highlight/highlightediting~HighlightEditing Highlight feature}.
+ *
+ *        ClassicEditor
+ *            .create( editorElement, {
+ * 				highlight:  ... // Highlight feature config.
+ *			} )
+ *            .then( ... )
+ *            .catch( ... );
+ *
+ * See {@link module:core/editor/editorconfig~EditorConfig all editor options}.
+ *
+ * @interface HighlightEditingConfig
+ */
+
+/**
+ * Available highlighters options.
+ *
+ * There are two types of highlighters:
+ * - 'marker' - rendered as `<mark>` element with defined background color.
+ * - 'pen' - rendered as `<mark>` element with defined foreground (font) color.
+ *
+ * Note: Each highlighter must have it's own CSS class defined to properly match content data. Also it is advised
+ * that color value should match the values defined in content CSS stylesheet.
+ *
+ * @member {Array.<module:heading/heading~HeadingOption>} module:heading/heading~HeadingConfig#options
+ */

--- a/src/highlightediting.js
+++ b/src/highlightediting.js
@@ -42,13 +42,7 @@ export default class HighlightEditing extends Plugin {
 		buildModelConverter()
 			.for( data.modelToView, editing.modelToView )
 			.fromAttribute( 'highlight' )
-			.toElement( data => {
-				const attributeElement = new AttributeElement( 'mark' );
-
-				attributeElement.addClass( data );
-
-				return attributeElement;
-			} );
+			.toElement( data => new AttributeElement( 'mark', { class: data } ) );
 
 		const configuredClasses = editor.config.get( 'highlight' ).map( config => config.class );
 

--- a/src/highlightediting.js
+++ b/src/highlightediting.js
@@ -21,6 +21,14 @@ export default class HighlightEditing extends Plugin {
 	init() {
 		const editor = this.editor;
 
+		editor.config.define( 'highlight', [
+			{ class: 'marker', title: 'Marker', color: '#ffff66', type: 'marker' },
+			{ class: 'marker-green', title: 'Green Marker', color: '#66ff00', type: 'marker' },
+			{ class: 'marker-pink', title: 'Pink Marker', color: '#ff6fff', type: 'marker' },
+			{ class: 'pen-red', title: 'Red Pen', color: '#ff0000', type: 'pen' },
+			{ class: 'pen-blue', title: 'Blue Pen', color: '#0000ff', type: 'pen' }
+		] );
+
 		editor.commands.add( 'highlight', new HighlightCommand( editor ) );
 	}
 }

--- a/src/highlightediting.js
+++ b/src/highlightediting.js
@@ -1,0 +1,26 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module highlight/highlightediting
+ */
+
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+
+import HighlightCommand from './highlightcommand';
+
+/**
+ * @extends module:core/plugin~Plugin
+ */
+export default class HighlightEditing extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	init() {
+		const editor = this.editor;
+
+		editor.commands.add( 'highlight', new HighlightCommand( editor ) );
+	}
+}

--- a/src/highlightediting.js
+++ b/src/highlightediting.js
@@ -87,8 +87,9 @@ export default class HighlightEditing extends Plugin {
  * @property {String} class The class which is used to differentiate highlighters.
  * @property {String} title The user-readable title of the option.
  * @property {String} color Color used for highlighter. Should be coherent with CSS class definition.
- * @property {'marker'|'pen'} type The type of highlighter. Either "marker" - will use #color as background name
- * of the view element that will be used to represent the model element in the view.
+ * @property {'marker'|'pen'} type The type of highlighter:
+ * - "marker" - will use #color as background,
+ * - "pen" - will use #color as font color.
  */
 
 /**
@@ -96,7 +97,7 @@ export default class HighlightEditing extends Plugin {
  *
  * Read more in {@link module:highlight/highlightediting~HighlightEditingConfig}.
  *
- * @member {module:highlight/highlightediting~HighlightEditingConfig} module:core/editor/editorconfig~EditorConfig#alignment
+ * @member {module:highlight/highlightediting~HighlightEditingConfig} module:core/editor/editorconfig~EditorConfig#highlight
  */
 
 /**

--- a/src/highlightediting.js
+++ b/src/highlightediting.js
@@ -47,6 +47,8 @@ export default class HighlightEditing extends Plugin {
 
 		// Allow highlight attribute on all elements
 		editor.document.schema.allow( { name: '$inline', attributes: 'highlight', inside: '$block' } );
+		// Temporary workaround. See https://github.com/ckeditor/ckeditor5/issues/477.
+		editor.document.schema.allow( { name: '$inline', attributes: 'highlight', inside: '$clipboardHolder' } );
 
 		// Convert highlight attribute to a mark element with associated class.
 		buildModelConverter()

--- a/src/highlightediting.js
+++ b/src/highlightediting.js
@@ -63,9 +63,7 @@ export default class HighlightEditing extends Plugin {
 			.for( data.viewToModel )
 			.fromElement( 'mark' )
 			.toAttribute( viewElement => {
-				const viewClassNames = [ ...viewElement.getClassNames() ];
-
-				for ( const className of viewClassNames ) {
+				for ( const className of viewElement.getClassNames() ) {
 					if ( configuredClasses.indexOf( className ) > -1 ) {
 						return { key: 'highlight', value: className };
 					}

--- a/src/highlightediting.js
+++ b/src/highlightediting.js
@@ -10,6 +10,10 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
 import HighlightCommand from './highlightcommand';
+import buildViewConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildviewconverter';
+import buildModelConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildmodelconverter';
+
+import AttributeElement from '@ckeditor/ckeditor5-engine/src/view/attributeelement';
 
 /**
  * @extends module:core/plugin~Plugin
@@ -20,6 +24,8 @@ export default class HighlightEditing extends Plugin {
 	 */
 	init() {
 		const editor = this.editor;
+		const data = editor.data;
+		const editing = editor.editing;
 
 		editor.config.define( 'highlight', [
 			{ class: 'marker', title: 'Marker', color: '#ffff66', type: 'marker' },
@@ -28,6 +34,43 @@ export default class HighlightEditing extends Plugin {
 			{ class: 'pen-red', title: 'Red Pen', color: '#ff0000', type: 'pen' },
 			{ class: 'pen-blue', title: 'Blue Pen', color: '#0000ff', type: 'pen' }
 		] );
+
+		// Allow highlight attribute on all elements
+		editor.document.schema.allow( { name: '$inline', attributes: 'highlight', inside: '$block' } );
+
+		// Convert highlight attribute to a mark element with associated class.
+		buildModelConverter()
+			.for( data.modelToView, editing.modelToView )
+			.fromAttribute( 'highlight' )
+			.toElement( data => {
+				const attributeElement = new AttributeElement( 'mark' );
+
+				attributeElement.addClass( data );
+
+				return attributeElement;
+			} );
+
+		const configuredClasses = editor.config.get( 'highlight' ).map( config => config.class );
+
+		// Convert `mark` attribute with class name to model's highlight attribute.
+		buildViewConverter()
+			.for( data.viewToModel )
+			.fromElement( 'mark' )
+			.toAttribute( viewElement => {
+				const viewClassNames = [ ...viewElement.getClassNames() ];
+
+				if ( !viewClassNames.length ) {
+					return;
+				}
+
+				const highlightClassNames = viewClassNames.filter( className => configuredClasses.includes( className ) );
+
+				if ( !highlightClassNames.length ) {
+					return;
+				}
+
+				return { key: 'highlight', value: highlightClassNames[ 0 ] };
+			} );
 
 		editor.commands.add( 'highlight', new HighlightCommand( editor ) );
 	}

--- a/src/highlightediting.js
+++ b/src/highlightediting.js
@@ -25,10 +25,8 @@ export default class HighlightEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	init() {
-		const editor = this.editor;
-		const data = editor.data;
-		const editing = editor.editing;
+	constructor( editor ) {
+		super( editor );
 
 		editor.config.define( 'highlight', [
 			{ class: 'marker', title: 'Marker', color: '#ffff66', type: 'marker' },
@@ -37,6 +35,15 @@ export default class HighlightEditing extends Plugin {
 			{ class: 'pen-red', title: 'Red Pen', color: '#ff0000', type: 'pen' },
 			{ class: 'pen-blue', title: 'Blue Pen', color: '#0000ff', type: 'pen' }
 		] );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	init() {
+		const editor = this.editor;
+		const data = editor.data;
+		const editing = editor.editing;
 
 		// Allow highlight attribute on all elements
 		editor.document.schema.allow( { name: '$inline', attributes: 'highlight', inside: '$block' } );

--- a/src/highlightui.js
+++ b/src/highlightui.js
@@ -30,11 +30,4 @@ export default class HighlightUI extends Plugin {
 	static get pluginName() {
 		return 'HighlightUI';
 	}
-
-	/**
-	 * @inheritDoc
-	 */
-	init() {
-		// TODO
-	}
 }

--- a/src/highlightui.js
+++ b/src/highlightui.js
@@ -1,0 +1,40 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module highlight/highlightui
+ */
+
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+
+import HighlightEditing from './highlightediting';
+
+/**
+ * The default Highlight UI plugin.
+ *
+ * @extends module:core/plugin~Plugin
+ */
+export default class HighlightUI extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	static get requires() {
+		return [ HighlightEditing ];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	static get pluginName() {
+		return 'HighlightUI';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	init() {
+		// TODO
+	}
+}

--- a/tests/highlight.js
+++ b/tests/highlight.js
@@ -1,0 +1,39 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* global document */
+
+import Highlight from './../src/highlight';
+import HighlightEditing from './../src/highlightediting';
+import HighlightUI from './../src/highlightui';
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+
+describe( 'Highlight', () => {
+	let editor, element;
+
+	beforeEach( () => {
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+
+		return ClassicTestEditor
+			.create( element, {
+				plugins: [ Highlight ]
+			} )
+			.then( newEditor => {
+				editor = newEditor;
+			} );
+	} );
+
+	afterEach( () => {
+		element.remove();
+
+		return editor.destroy();
+	} );
+
+	it( 'requires HighlightEditing and HighlightUI', () => {
+		expect( Highlight.requires ).to.deep.equal( [ HighlightEditing, HighlightUI ] );
+	} );
+} );

--- a/tests/highlightcommand.js
+++ b/tests/highlightcommand.js
@@ -98,5 +98,17 @@ describe( 'HighlightCommand', () => {
 
 			expect( command.value ).to.be.undefined;
 		} );
+
+		it( 'should do nothing on collapsed range', () => {
+			setData( doc, '<paragraph>abc<$text highlight="marker">foo[]bar</$text>xyz</paragraph>' );
+
+			expect( command.value ).to.equal( 'marker' );
+
+			command.execute();
+
+			expect( getData( doc ) ).to.equal( '<paragraph>abc<$text highlight="marker">foo[]bar</$text>xyz</paragraph>' );
+
+			expect( command.value ).to.equal( 'marker' );
+		} );
 	} );
 } );

--- a/tests/highlightcommand.js
+++ b/tests/highlightcommand.js
@@ -5,10 +5,11 @@
 
 import HighlightCommand from './../src/highlightcommand';
 
-import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
+import { getData, setData } from '../../ckeditor5-engine/src/dev-utils/model';
 
 describe( 'HighlightCommand', () => {
 	let editor, doc, command;
@@ -59,15 +60,43 @@ describe( 'HighlightCommand', () => {
 		} );
 	} );
 
-	describe.skip( 'execute()', () => {
-		describe( 'applying highlight', () => {
-			it( 'adds highlight to selected text element', () => {
-				setModelData( doc, '<paragraph>f[o]o</paragraph>' );
+	describe( 'execute()', () => {
+		it( 'should add highlight attribute on selected nodes nodes when passed as parameter', () => {
+			setData( doc, '<paragraph>a[bc<$text highlight="marker">fo]obar</$text>xyz</paragraph>' );
 
-				editor.execute( 'highlight', { class: 'marker' } );
+			expect( command.value ).to.be.undefined;
 
-				expect( getModelData( doc ) ).to.equal( '<paragraph>f<$text highlight="marker">[o]</$text>o</paragraph>' );
-			} );
+			command.execute( { class: 'marker' } );
+
+			expect( command.value ).to.equal( 'marker' );
+
+			expect( getData( doc ) ).to.equal( '<paragraph>a[<$text highlight="marker">bcfo]obar</$text>xyz</paragraph>' );
+		} );
+
+		it( 'should set highlight attribute on selected nodes when passed as parameter', () => {
+			setData( doc, '<paragraph>abc[<$text highlight="marker">foo]bar</$text>xyz</paragraph>' );
+
+			expect( command.value ).to.equal( 'marker' );
+
+			command.execute( { class: 'foo' } );
+
+			expect( getData( doc ) ).to.equal(
+				'<paragraph>abc[<$text highlight="foo">foo</$text>]<$text highlight="marker">bar</$text>xyz</paragraph>'
+			);
+
+			expect( command.value ).to.equal( 'foo' );
+		} );
+
+		it( 'should remove highlight attribute on selected nodes nodes when undefined passed as parameter', () => {
+			setData( doc, '<paragraph>abc[<$text highlight="marker">foo]bar</$text>xyz</paragraph>' );
+
+			expect( command.value ).to.equal( 'marker' );
+
+			command.execute();
+
+			expect( getData( doc ) ).to.equal( '<paragraph>abc[foo]<$text highlight="marker">bar</$text>xyz</paragraph>' );
+
+			expect( command.value ).to.be.undefined;
 		} );
 	} );
 } );

--- a/tests/highlightcommand.js
+++ b/tests/highlightcommand.js
@@ -5,11 +5,9 @@
 
 import HighlightCommand from './../src/highlightcommand';
 
-import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-
 import Command from '@ckeditor/ckeditor5-core/src/command';
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
-import { getData, setData } from '../../ckeditor5-engine/src/dev-utils/model';
+import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 describe( 'HighlightCommand', () => {
 	let editor, doc, command;
@@ -40,13 +38,13 @@ describe( 'HighlightCommand', () => {
 
 	describe( 'value', () => {
 		it( 'is set to highlight attribute value when selection is in text with highlight attribute', () => {
-			setModelData( doc, '<paragraph><$text highlight="marker">fo[]o</$text></paragraph>' );
+			setData( doc, '<paragraph><$text highlight="marker">fo[]o</$text></paragraph>' );
 
 			expect( command ).to.have.property( 'value', 'marker' );
 		} );
 
 		it( 'is undefined when selection is not in text with highlight attribute', () => {
-			setModelData( doc, '<paragraph>fo[]o</paragraph>' );
+			setData( doc, '<paragraph>fo[]o</paragraph>' );
 
 			expect( command ).to.have.property( 'value', undefined );
 		} );
@@ -54,7 +52,7 @@ describe( 'HighlightCommand', () => {
 
 	describe( 'isEnabled', () => {
 		it( 'is true when selection is on text which can have highlight added', () => {
-			setModelData( doc, '<paragraph>fo[]o</paragraph>' );
+			setData( doc, '<paragraph>fo[]o</paragraph>' );
 
 			expect( command ).to.have.property( 'isEnabled', true );
 		} );

--- a/tests/highlightcommand.js
+++ b/tests/highlightcommand.js
@@ -24,7 +24,7 @@ describe( 'HighlightCommand', () => {
 
 				doc.schema.registerItem( 'paragraph', '$block' );
 
-				doc.schema.allow( { name: '$block', inside: '$root', attributes: 'highlight' } );
+				doc.schema.allow( { name: '$inline', attributes: 'highlight', inside: '$block' } );
 			} );
 	} );
 
@@ -38,16 +38,22 @@ describe( 'HighlightCommand', () => {
 	} );
 
 	describe( 'value', () => {
-		it( 'is true when selection is in block with commend type highlight', () => {
-			setModelData( doc, '<paragraph highlight="center"><$text highlight="true">fo[]o</$text></paragraph>' );
+		it( 'is set to highlight attribute value when selection is in text with highlight attribute', () => {
+			setModelData( doc, '<paragraph><$text highlight="marker">fo[]o</$text></paragraph>' );
 
-			expect( command ).to.have.property( 'value', true );
+			expect( command ).to.have.property( 'value', 'marker' );
+		} );
+
+		it( 'is undefined when selection is not in text with highlight attribute', () => {
+			setModelData( doc, '<paragraph>fo[]o</paragraph>' );
+
+			expect( command ).to.have.property( 'value', undefined );
 		} );
 	} );
 
 	describe( 'isEnabled', () => {
-		it( 'is true when selection is in a block which can have added highlight', () => {
-			setModelData( doc, '<paragraph highlight="center"><$text highlight="true">fo[]o</$text></paragraph>' );
+		it( 'is true when selection is on text which can have highlight added', () => {
+			setModelData( doc, '<paragraph>fo[]o</paragraph>' );
 
 			expect( command ).to.have.property( 'isEnabled', true );
 		} );
@@ -58,9 +64,9 @@ describe( 'HighlightCommand', () => {
 			it( 'adds highlight to selected text element', () => {
 				setModelData( doc, '<paragraph>f[o]o</paragraph>' );
 
-				editor.execute( 'highlight' );
+				editor.execute( 'highlight', { class: 'marker' } );
 
-				expect( getModelData( doc ) ).to.equal( '<paragraph>f<$text highlight="true">[o]</$text>o</paragraph>' );
+				expect( getModelData( doc ) ).to.equal( '<paragraph>f<$text highlight="marker">[o]</$text>o</paragraph>' );
 			} );
 		} );
 	} );

--- a/tests/highlightcommand.js
+++ b/tests/highlightcommand.js
@@ -1,0 +1,67 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import HighlightCommand from './../src/highlightcommand';
+
+import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+
+import Command from '@ckeditor/ckeditor5-core/src/command';
+import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
+
+describe( 'HighlightCommand', () => {
+	let editor, doc, command;
+
+	beforeEach( () => {
+		return ModelTestEditor.create()
+			.then( newEditor => {
+				doc = newEditor.document;
+				command = new HighlightCommand( newEditor );
+				editor = newEditor;
+
+				editor.commands.add( 'highlight', command );
+
+				doc.schema.registerItem( 'paragraph', '$block' );
+
+				doc.schema.allow( { name: '$block', inside: '$root', attributes: 'highlight' } );
+			} );
+	} );
+
+	afterEach( () => {
+		editor.destroy();
+	} );
+
+	it( 'is a command', () => {
+		expect( HighlightCommand.prototype ).to.be.instanceOf( Command );
+		expect( command ).to.be.instanceOf( Command );
+	} );
+
+	describe( 'value', () => {
+		it( 'is true when selection is in block with commend type highlight', () => {
+			setModelData( doc, '<paragraph highlight="center"><$text highlight="true">fo[]o</$text></paragraph>' );
+
+			expect( command ).to.have.property( 'value', true );
+		} );
+	} );
+
+	describe( 'isEnabled', () => {
+		it( 'is true when selection is in a block which can have added highlight', () => {
+			setModelData( doc, '<paragraph highlight="center"><$text highlight="true">fo[]o</$text></paragraph>' );
+
+			expect( command ).to.have.property( 'isEnabled', true );
+		} );
+	} );
+
+	describe.skip( 'execute()', () => {
+		describe( 'applying highlight', () => {
+			it( 'adds highlight to selected text element', () => {
+				setModelData( doc, '<paragraph>f[o]o</paragraph>' );
+
+				editor.execute( 'highlight' );
+
+				expect( getModelData( doc ) ).to.equal( '<paragraph>f<$text highlight="true">[o]</$text>o</paragraph>' );
+			} );
+		} );
+	} );
+} );

--- a/tests/highlightcommand.js
+++ b/tests/highlightcommand.js
@@ -71,6 +71,25 @@ describe( 'HighlightCommand', () => {
 			expect( getData( doc ) ).to.equal( '<paragraph>a[<$text highlight="marker">bcfo]obar</$text>xyz</paragraph>' );
 		} );
 
+		it( 'should add highlight attribute on selected nodes nodes when passed as parameter (multiple nodes)', () => {
+			setData(
+				doc,
+				'<paragraph>abcabc[abc</paragraph>' +
+				'<paragraph>foofoofoo</paragraph>' +
+				'<paragraph>barbar]bar</paragraph>'
+			);
+
+			command.execute( { class: 'marker' } );
+
+			expect( command.value ).to.equal( 'marker' );
+
+			expect( getData( doc ) ).to.equal(
+				'<paragraph>abcabc[<$text highlight="marker">abc</$text></paragraph>' +
+				'<paragraph><$text highlight="marker">foofoofoo</$text></paragraph>' +
+				'<paragraph><$text highlight="marker">barbar</$text>]bar</paragraph>'
+			);
+		} );
+
 		it( 'should set highlight attribute on selected nodes when passed as parameter', () => {
 			setData( doc, '<paragraph>abc[<$text highlight="marker">foo]bar</$text>xyz</paragraph>' );
 

--- a/tests/highlightediting.js
+++ b/tests/highlightediting.js
@@ -30,6 +30,11 @@ describe( 'HighlightEditing', () => {
 		editor.destroy();
 	} );
 
+	it( 'should set proper schema rules', () => {
+		expect( doc.schema.check( { name: '$inline', attributes: 'highlight', inside: '$block' } ) ).to.be.true;
+		expect( doc.schema.check( { name: '$inline', attributes: 'highlight', inside: '$clipboardHolder' } ) ).to.be.true;
+	} );
+
 	it( 'adds highlight commands', () => {
 		expect( editor.commands.get( 'highlight' ) ).to.be.instanceOf( HighlightCommand );
 	} );

--- a/tests/highlightediting.js
+++ b/tests/highlightediting.js
@@ -1,0 +1,91 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import HighlightEditing from './../src/highlightediting';
+import HighlightCommand from './../src/highlightcommand';
+
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+
+import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
+import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+
+describe( 'HighlightEditing', () => {
+	let editor, doc;
+
+	beforeEach( () => {
+		return VirtualTestEditor
+			.create( {
+				plugins: [ HighlightEditing, Paragraph ]
+			} )
+			.then( newEditor => {
+				editor = newEditor;
+
+				doc = editor.document;
+			} );
+	} );
+
+	afterEach( () => {
+		editor.destroy();
+	} );
+
+	it( 'adds highlight commands', () => {
+		expect( editor.commands.get( 'highlight' ) ).to.be.instanceOf( HighlightCommand );
+	} );
+
+	it.skip( 'allows for highlight in $blocks', () => {
+		expect( doc.schema.check( { name: '$text', inside: '$root', attributes: 'highlight' } ) ).to.be.true;
+	} );
+
+	describe.skip( 'integration', () => {
+		beforeEach( () => {
+			return VirtualTestEditor
+				.create( {
+					plugins: [ HighlightEditing, Paragraph ]
+				} )
+				.then( newEditor => {
+					editor = newEditor;
+
+					doc = editor.document;
+				} );
+		} );
+
+		it( 'is allowed inside paragraph', () => {
+			expect( doc.schema.check( { name: 'paragraph', attributes: 'highlight' } ) ).to.be.true;
+		} );
+	} );
+
+	describe.skip( 'highlight', () => {
+		it( 'adds converters to the data pipeline', () => {
+			const data = '<p>f<mark>o</mark>o</p>';
+
+			editor.setData( data );
+
+			expect( getModelData( doc ) ).to.equal( '<paragraph>f<$text highlight="">o</$text>o</paragraph>' );
+			expect( editor.getData() ).to.equal( '<p>x</p>' );
+		} );
+
+		it( 'adds a converter to the view pipeline for removing attribute', () => {
+			setModelData( doc, '<paragraph>f<$text highlight="">o</$text>o</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>f<mark>o</mark>o</p>' );
+
+			const command = editor.commands.get( 'highlight' );
+
+			command.execute();
+
+			expect( editor.getData() ).to.equal( '<p>x</p>' );
+		} );
+	} );
+
+	describe.skip( 'config', () => {
+		describe( 'styles', () => {
+			describe( 'default value', () => {
+				it( 'should be set', () => {
+					expect( editor.config.get( 'highlight.styles' ) ).to.deep.equal( {} );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/tests/highlightediting.js
+++ b/tests/highlightediting.js
@@ -56,28 +56,42 @@ describe( 'HighlightEditing', () => {
 		} );
 	} );
 
-	describe.skip( 'data pipeline conversions', () => {
+	describe( 'data pipeline conversions', () => {
 		it( 'should convert defined marker classes', () => {
 			const data = '<p>f<mark class="marker">o</mark>o</p>';
 
 			editor.setData( data );
 
-			expect( getModelData( doc ) ).to.equal( '<paragraph>f<$text highlight="">o</$text>o</paragraph>' );
-			expect( editor.getData() ).to.equal( '<p>x</p>' );
+			expect( getModelData( doc ) ).to.equal( '<paragraph>[]f<$text highlight="marker">o</$text>o</paragraph>' );
+			expect( editor.getData() ).to.equal( data );
+		} );
+		it( 'should convert only one defined marker classes', () => {
+			editor.setData( '<p>f<mark class="marker-green marker">o</mark>o</p>' );
+
+			expect( getModelData( doc ) ).to.equal( '<paragraph>[]f<$text highlight="marker-green">o</$text>o</paragraph>' );
+			expect( editor.getData() ).to.equal( '<p>f<mark class="marker-green">o</mark>o</p>' );
+		} );
+
+		it( 'should not convert undefined marker classes', () => {
+			editor.setData( '<p>f<mark class="some-unknown-marker">o</mark>o</p>' );
+
+			expect( getModelData( doc ) ).to.equal( '<paragraph>[]foo</paragraph>' );
+			expect( editor.getData() ).to.equal( '<p>foo</p>' );
+		} );
+
+		it( 'should not convert marker without class', () => {
+			editor.setData( '<p>f<mark>o</mark>o</p>' );
+
+			expect( getModelData( doc ) ).to.equal( '<paragraph>[]foo</paragraph>' );
+			expect( editor.getData() ).to.equal( '<p>foo</p>' );
 		} );
 	} );
 
-	describe.skip( 'editing pipeline conversion', () => {
-		it( 'adds a converter to the view pipeline for removing attribute', () => {
-			setModelData( doc, '<paragraph>f<$text highlight="">o</$text>o</paragraph>' );
+	describe( 'editing pipeline conversion', () => {
+		it( 'should convert mark element with defined class', () => {
+			setModelData( doc, '<paragraph>f<$text highlight="marker">o</$text>o</paragraph>' );
 
-			expect( editor.getData() ).to.equal( '<p>f<mark>o</mark>o</p>' );
-
-			const command = editor.commands.get( 'highlight' );
-
-			command.execute();
-
-			expect( editor.getData() ).to.equal( '<p>x</p>' );
+			expect( editor.getData() ).to.equal( '<p>f<mark class="marker">o</mark>o</p>' );
 		} );
 	} );
 

--- a/tests/highlightediting.js
+++ b/tests/highlightediting.js
@@ -56,16 +56,18 @@ describe( 'HighlightEditing', () => {
 		} );
 	} );
 
-	describe.skip( 'highlight', () => {
-		it( 'adds converters to the data pipeline', () => {
-			const data = '<p>f<mark>o</mark>o</p>';
+	describe.skip( 'data pipeline conversions', () => {
+		it( 'should convert defined marker classes', () => {
+			const data = '<p>f<mark class="marker">o</mark>o</p>';
 
 			editor.setData( data );
 
 			expect( getModelData( doc ) ).to.equal( '<paragraph>f<$text highlight="">o</$text>o</paragraph>' );
 			expect( editor.getData() ).to.equal( '<p>x</p>' );
 		} );
+	} );
 
+	describe.skip( 'editing pipeline conversion', () => {
 		it( 'adds a converter to the view pipeline for removing attribute', () => {
 			setModelData( doc, '<paragraph>f<$text highlight="">o</$text>o</paragraph>' );
 
@@ -79,12 +81,16 @@ describe( 'HighlightEditing', () => {
 		} );
 	} );
 
-	describe.skip( 'config', () => {
-		describe( 'styles', () => {
-			describe( 'default value', () => {
-				it( 'should be set', () => {
-					expect( editor.config.get( 'highlight.styles' ) ).to.deep.equal( {} );
-				} );
+	describe( 'config', () => {
+		describe( 'default value', () => {
+			it( 'should be set', () => {
+				expect( editor.config.get( 'highlight' ) ).to.deep.equal( [
+					{ class: 'marker', title: 'Marker', color: '#ffff66', type: 'marker' },
+					{ class: 'marker-green', title: 'Green Marker', color: '#66ff00', type: 'marker' },
+					{ class: 'marker-pink', title: 'Pink Marker', color: '#ff6fff', type: 'marker' },
+					{ class: 'pen-red', title: 'Red Pen', color: '#ff0000', type: 'pen' },
+					{ class: 'pen-blue', title: 'Blue Pen', color: '#0000ff', type: 'pen' }
+				] );
 			} );
 		} );
 	} );

--- a/tests/highlightediting.js
+++ b/tests/highlightediting.js
@@ -34,28 +34,6 @@ describe( 'HighlightEditing', () => {
 		expect( editor.commands.get( 'highlight' ) ).to.be.instanceOf( HighlightCommand );
 	} );
 
-	it.skip( 'allows for highlight in $blocks', () => {
-		expect( doc.schema.check( { name: '$text', inside: '$root', attributes: 'highlight' } ) ).to.be.true;
-	} );
-
-	describe.skip( 'integration', () => {
-		beforeEach( () => {
-			return VirtualTestEditor
-				.create( {
-					plugins: [ HighlightEditing, Paragraph ]
-				} )
-				.then( newEditor => {
-					editor = newEditor;
-
-					doc = editor.document;
-				} );
-		} );
-
-		it( 'is allowed inside paragraph', () => {
-			expect( doc.schema.check( { name: 'paragraph', attributes: 'highlight' } ) ).to.be.true;
-		} );
-	} );
-
 	describe( 'data pipeline conversions', () => {
 		it( 'should convert defined marker classes', () => {
 			const data = '<p>f<mark class="marker">o</mark>o</p>';

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -1,0 +1,69 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* global document */
+
+import Highlight from '../src/highlight';
+import BlockQuote from '@ckeditor/ckeditor5-block-quote/src/blockquote';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+import Image from '@ckeditor/ckeditor5-image/src/image';
+import ImageCaption from '@ckeditor/ckeditor5-image/src/imagecaption';
+import List from '@ckeditor/ckeditor5-list/src/list';
+import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import Delete from '@ckeditor/ckeditor5-typing/src/delete';
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+
+describe( 'Highlight', () => {
+	let editor, doc, element;
+
+	beforeEach( () => {
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+
+		return ClassicTestEditor
+			.create( element, {
+				plugins: [ Highlight, BlockQuote, Paragraph, Heading, Image, ImageCaption, List, Enter, Delete ]
+			} )
+			.then( newEditor => {
+				editor = newEditor;
+				doc = editor.document;
+			} );
+	} );
+
+	afterEach( () => {
+		element.remove();
+
+		return editor.destroy();
+	} );
+
+	describe( 'compatibility with images', () => {
+		it( 'does not work inside image caption', () => {
+			setModelData( doc, '<image src="foo.png"><caption>foo[bar]baz</caption></image>' );
+
+			editor.execute( 'highlight', { class: 'marker' } );
+
+			expect( getModelData( doc ) )
+				.to.equal( '<image src="foo.png"><caption>foo[<$text highlight="marker">bar</$text>]baz</caption></image>' );
+		} );
+
+		it( 'does not work on selection with image', () => {
+			setModelData(
+				doc,
+				'<paragraph>foo[foo</paragraph><image src="foo.png"><caption>abc</caption></image><paragraph>bar]bar</paragraph>'
+			);
+
+			editor.execute( 'highlight', { class: 'marker' } );
+
+			expect( getModelData( doc ) ).to.equal(
+				'<paragraph>foo[<$text highlight="marker">foo</$text></paragraph>' +
+				'<image src="foo.png"><caption><$text highlight="marker">abc</$text></caption></image>' +
+				'<paragraph><$text highlight="marker">bar</$text>]bar</paragraph>'
+			);
+		} );
+	} );
+} );

--- a/tests/manual/highlight.html
+++ b/tests/manual/highlight.html
@@ -23,27 +23,11 @@
 
 </style>
 <div id="editor">
-	<p>Lorem
-		<mark class="marker">ipsum dolor sit amet</mark>
-		, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et <mark class="pen-red">dolore magna</mark> aliqua. Ut enim ad minim veniam, quis
-		nostrud exercitation ullamco
-		<mark class="pen-blue">laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-			velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-		</mark>
-		cupidatat non proident, sunt in culpa qui officia
-		deserunt mollit anim id est laborum.
+	<p>Highlight feature example.</p>
+	<p>Here ares some markers:
+		<mark class="marker">yellow one</mark>, <mark class="marker-pink">pink one</mark> and <mark class="marker-green">green one</mark>.
 	</p>
-	<p>Lorem ipsum dolor sit amet, consectetur
-		<mark class="marker-green">adipiscing elit</mark>
-		, sed do eiusmod tempor incididunt ut labore et dolore magna
-		<mark>aliqua. Ut enim ad minim veniam</mark>
-		, quis nostrud exercitation ullamco
-		<mark class="marker-pink">laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
-			esse cillum dolore eu
-		</mark>
-		fugiat nulla pariatur.
-		<mark class="pen-red">Excepteur</mark>
-		sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
-		laborum.
+	<p>Here ares some pens:
+		<mark class="pen-red">red pen</mark> and <mark class="pen-blue">blue one</mark>.
 	</p>
 </div>

--- a/tests/manual/highlight.html
+++ b/tests/manual/highlight.html
@@ -1,0 +1,49 @@
+<style>
+	.marker {
+		background-color: #ffff66;
+	}
+
+	.marker-green {
+		background-color: #66ff00;
+	}
+
+	.marker-pink {
+		background-color: #ff6fff;
+	}
+
+	.pen-red {
+		background-color: transparent;
+		color: #ff0000;
+	}
+
+	.pen-blue {
+		background-color: transparent;
+		color: #0000ff;
+	}
+
+</style>
+<div id="editor">
+	<p>Lorem
+		<mark class="marker">ipsum dolor sit amet</mark>
+		, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et <mark class="pen-red">dolore magna</mark> aliqua. Ut enim ad minim veniam, quis
+		nostrud exercitation ullamco
+		<mark class="pen-blue">laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+			velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+		</mark>
+		cupidatat non proident, sunt in culpa qui officia
+		deserunt mollit anim id est laborum.
+	</p>
+	<p>Lorem ipsum dolor sit amet, consectetur
+		<mark class="marker-green">adipiscing elit</mark>
+		, sed do eiusmod tempor incididunt ut labore et dolore magna
+		<mark>aliqua. Ut enim ad minim veniam</mark>
+		, quis nostrud exercitation ullamco
+		<mark class="marker-pink">laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+			esse cillum dolore eu
+		</mark>
+		fugiat nulla pariatur.
+		<mark class="pen-red">Excepteur</mark>
+		sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+		laborum.
+	</p>
+</div>

--- a/tests/manual/highlight.js
+++ b/tests/manual/highlight.js
@@ -1,0 +1,24 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '../../../ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '../../../ckeditor5-core/tests/_utils/articlepluginset';
+import Highlight from '../../src/highlight';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ ArticlePluginSet, Highlight ],
+		toolbar: [
+			'headings', 'bold', 'italic', 'link', 'mark', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
+		]
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/tests/manual/highlight.js
+++ b/tests/manual/highlight.js
@@ -13,7 +13,7 @@ ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [ ArticlePluginSet, Highlight ],
 		toolbar: [
-			'headings', 'bold', 'italic', 'link', 'mark', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
+			'headings', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
 		]
 	} )
 	.then( editor => {

--- a/tests/manual/highlight.md
+++ b/tests/manual/highlight.md
@@ -6,4 +6,13 @@
 
 You should be able to:
 - see different markers class
-- manually invoke highlight command in console
+- manually invoke highlight command in console:
+
+```
+editor.execute( 'highlight', { class: 'marker' } );
+editor.execute( 'highlight', { class: 'marker-green' } );
+editor.execute( 'highlight', { class: 'marker-pink' } );
+	
+editor.execute( 'highlight', { class: 'pen-red' } );
+editor.execute( 'highlight', { class: 'pen-blue' } );	 
+```

--- a/tests/manual/highlight.md
+++ b/tests/manual/highlight.md
@@ -1,9 +1,9 @@
 ### Loading
 
-1. The data should be loaded with:
+1. The data should be loaded with different markers and pens.
 
 ### Testing
 
 You should be able to:
-
-
+- see different markers class
+- manually invoke highlight command in console

--- a/tests/manual/highlight.md
+++ b/tests/manual/highlight.md
@@ -1,0 +1,9 @@
+### Loading
+
+1. The data should be loaded with:
+
+### Testing
+
+You should be able to:
+
+


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Initial implementation of highlight editing. Closes #1.

---

### Additional information

This PR comes with changes in other packages branches:
- https://github.com/ckeditor/ckeditor5/tree/t/ckeditor5-highlight/1 (introduced package + updated mgit.json for PR review).

Merge commit message for related branches:
- ckeditor5: `Feature: Introduce ckeditor5-highlight package.`

Misc
* The initial implementation comes with stubs for Highlight UI but without any implementation.
* I've implemented highlight as simples as possible - hence no `Markers` were used in view - only `<mark>` elements.
* I'm not sure if tests are not too simple (looking at other features).