### PR TITLE
Fix: Selection attribute is not updated on consecutive `HighlightCommand#execute()` calls.

### DIFF
--- a/src/highlightcommand.js
+++ b/src/highlightcommand.js
@@ -84,6 +84,7 @@ export default class HighlightCommand extends Command {
 					} else {
 						// ...update `highlight` value.
 						writer.setAttribute( 'highlight', highlighter, highlightRange );
+						writer.setSelectionAttribute( 'highlight', highlighter );
 					}
 				} else if ( highlighter ) {
 					writer.setSelectionAttribute( 'highlight', highlighter );

--- a/tests/highlightcommand.js
+++ b/tests/highlightcommand.js
@@ -172,6 +172,22 @@ describe( 'HighlightCommand', () => {
 					expect( command.value ).to.be.undefined;
 					expect( doc.selection.hasAttribute( 'highlight' ) ).to.be.false;
 				} );
+
+				it( 'should change selection attribute on consecutive calls', () => {
+					setData( model, '<p>abcfoobar[] foobar</p>' );
+
+					expect( command.value ).to.be.undefined;
+
+					command.execute( { value: 'greenMarker' } );
+
+					expect( command.value ).to.equal( 'greenMarker' );
+					expect( doc.selection.hasAttribute( 'highlight' ) ).to.be.true;
+
+					command.execute( { value: 'pinkMarker' } );
+
+					expect( command.value ).to.equal( 'pinkMarker' );
+					expect( doc.selection.hasAttribute( 'highlight' ) ).to.be.true;
+				} );
 			} );
 
 			describe( 'on not collapsed range', () => {

--- a/tests/highlightcommand.js
+++ b/tests/highlightcommand.js
@@ -173,6 +173,7 @@ describe( 'HighlightCommand', () => {
 					expect( doc.selection.hasAttribute( 'highlight' ) ).to.be.false;
 				} );
 
+				// https://github.com/ckeditor/ckeditor5-highlight/issues/8
 				it( 'should change selection attribute on consecutive calls', () => {
 					setData( model, '<p>abcfoobar[] foobar</p>' );
 
@@ -181,12 +182,12 @@ describe( 'HighlightCommand', () => {
 					command.execute( { value: 'greenMarker' } );
 
 					expect( command.value ).to.equal( 'greenMarker' );
-					expect( doc.selection.hasAttribute( 'highlight' ) ).to.be.true;
+					expect( doc.selection.getAttribute( 'highlight' ) ).to.equal( 'greenMarker' );
 
 					command.execute( { value: 'pinkMarker' } );
 
 					expect( command.value ).to.equal( 'pinkMarker' );
-					expect( doc.selection.hasAttribute( 'highlight' ) ).to.be.true;
+					expect( doc.selection.getAttribute( 'highlight' ) ).to.equal( 'pinkMarker' );
 				} );
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Selection attribute is not updated on consecutive `HighlightCommand#execute()` calls. Closes #8.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
