### PR TITLE
Changed: HighlightUI should not require HighlightEditing.

### DIFF
--- a/src/highlightui.js
+++ b/src/highlightui.js
@@ -9,7 +9,6 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
-import HighlightEditing from './highlightediting';
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
 
 import markerIcon from './../theme/icons/marker.svg';
@@ -66,13 +65,6 @@ export default class HighlightUI extends Plugin {
 			'Red pen': t( 'Red pen' ),
 			'Green pen': t( 'Green pen' )
 		};
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	static get requires() {
-		return [ HighlightEditing ];
 	}
 
 	/**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `HighlightUI` should not require `HighlightEditing`.

------

### Additional information

* Part of feature split: https://github.com/ckeditor/ckeditor5/issues/488
