### PR TITLE
Other: Align code to the changes in naming UI components & commands.

### DIFF
--- a/docs/_snippets/features/custom-highlight-colors-inline.js
+++ b/docs/_snippets/features/custom-highlight-colors-inline.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'headings', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
+				'heading', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
 			],
 			viewportTopOffset: 60
 		},

--- a/docs/_snippets/features/custom-highlight-colors-inline.js
+++ b/docs/_snippets/features/custom-highlight-colors-inline.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
+				'heading', '|', 'bulletedList', 'numberedList', 'highlight', 'undo', 'redo'
 			],
 			viewportTopOffset: 60
 		},

--- a/docs/_snippets/features/custom-highlight-colors-variables.js
+++ b/docs/_snippets/features/custom-highlight-colors-variables.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'headings', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
+				'heading', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
 			],
 			viewportTopOffset: 60
 		},

--- a/docs/_snippets/features/custom-highlight-colors-variables.js
+++ b/docs/_snippets/features/custom-highlight-colors-variables.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
+				'heading', '|', 'bulletedList', 'numberedList', 'highlight', 'undo', 'redo'
 			],
 			viewportTopOffset: 60
 		},

--- a/docs/_snippets/features/custom-highlight-options.js
+++ b/docs/_snippets/features/custom-highlight-options.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'headings', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
+				'heading', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
 			],
 			viewportTopOffset: 60
 		},

--- a/docs/_snippets/features/custom-highlight-options.js
+++ b/docs/_snippets/features/custom-highlight-options.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
+				'heading', '|', 'bulletedList', 'numberedList', 'highlight', 'undo', 'redo'
 			],
 			viewportTopOffset: 60
 		},

--- a/docs/_snippets/features/highlight-buttons.js
+++ b/docs/_snippets/features/highlight-buttons.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'headings', '|', 'highlight:yellowMarker', 'highlight:greenMarker', 'highlight:pinkMarker',
+				'heading', '|', 'highlight:yellowMarker', 'highlight:greenMarker', 'highlight:pinkMarker',
 				'highlight:greenPen', 'highlight:redPen', 'removeHighlight', '|', 'undo', 'redo'
 			],
 			viewportTopOffset: 60

--- a/docs/_snippets/features/highlight.js
+++ b/docs/_snippets/features/highlight.js
@@ -9,7 +9,7 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-highlight' ), {
 		toolbar: {
 			items: [
-				'headings', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
+				'heading', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
 			],
 			viewportTopOffset: 60
 		}

--- a/docs/_snippets/features/highlight.js
+++ b/docs/_snippets/features/highlight.js
@@ -9,7 +9,7 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-highlight' ), {
 		toolbar: {
 			items: [
-				'heading', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
+				'heading', '|', 'bulletedList', 'numberedList', 'highlight', 'undo', 'redo'
 			],
 			viewportTopOffset: 60
 		}

--- a/docs/features/highlight.md
+++ b/docs/features/highlight.md
@@ -42,7 +42,7 @@ ClassicEditor
 			]
 		},
 		toolbar: [
-			'headings', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
+			'heading', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
 		]
 	} )
 	.then( ... )
@@ -60,7 +60,7 @@ ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		toolbar: {
 			items: [
-				'headings',
+				'heading',
 				'|',
 				'highlight:yellowMarker', 'highlight:greenMarker', 'highlight:pinkMarker',
 				'highlight:greenPen', 'highlight:redPen', 'removeHighlight',
@@ -133,7 +133,7 @@ ClassicEditor
 			]
 		},
 		toolbar: [
-			'headings', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
+			'heading', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
 		]
 	} )
 	.then( ... )

--- a/docs/features/highlight.md
+++ b/docs/features/highlight.md
@@ -42,7 +42,7 @@ ClassicEditor
 			]
 		},
 		toolbar: [
-			'heading', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
+			'heading', '|', 'bulletedList', 'numberedList', 'highlight', 'undo', 'redo'
 		]
 	} )
 	.then( ... )
@@ -53,7 +53,7 @@ ClassicEditor
 
 ### Inline buttons
 
-Instead of using the (default) `highlightDropdown`, the feature also supports a configuration with separate buttons directly in the toolbar:
+Instead of using the (default) `highlight`, the feature also supports a configuration with separate buttons directly in the toolbar:
 
 ```js
 ClassicEditor
@@ -133,7 +133,7 @@ ClassicEditor
 			]
 		},
 		toolbar: [
-			'heading', '|', 'bulletedList', 'numberedList', 'highlightDropdown', 'undo', 'redo'
+			'heading', '|', 'bulletedList', 'numberedList', 'highlight', 'undo', 'redo'
 		]
 	} )
 	.then( ... )
@@ -172,7 +172,7 @@ import Highlight from '@ckeditor/ckeditor5-highlight/src/highlight';
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [ Highlight, ... ],
-		toolbar: [ 'highlightDropdown', ... ]
+		toolbar: [ 'highlight', ... ]
 	} )
 	.then( ... )
 	.catch( ... );
@@ -186,7 +186,7 @@ ClassicEditor
 
 The {@link module:highlight/highlight~Highlight} plugin registers:
 
-* The `'highlightDropdown'` dropdown,
+* The `'highlight'` dropdown,
 * The {@link module:highlight/highlightcommand~HighlightCommand `'highlight'`} command.
 
 	The number of options and their names correspond to the {@link module:highlight/highlight~HighlightConfig#options `highlight.options`} configuration option.

--- a/src/highlightui.js
+++ b/src/highlightui.js
@@ -23,7 +23,7 @@ import './../theme/highlight.css';
 
 /**
  * The default Highlight UI plugin. It introduces:
- * * the `'highlightDropdown'` drop-down,
+ * * the `'highlight'` drop-down,
  * * `'removeHighlight'` and `'highlight:*'` buttons.
  *
  * The default configuration includes the following buttons:
@@ -175,7 +175,7 @@ export default class HighlightUI extends Plugin {
 			return retVal;
 		}, {} );
 
-		componentFactory.add( 'highlightDropdown', locale => {
+		componentFactory.add( 'highlight', locale => {
 			const command = editor.commands.get( 'highlight' );
 			const dropdownView = createDropdown( locale, SplitButtonView );
 			const splitButtonView = dropdownView.buttonView;

--- a/tests/highlightui.js
+++ b/tests/highlightui.js
@@ -72,7 +72,7 @@ describe( 'HighlightUI', () => {
 
 		beforeEach( () => {
 			command = editor.commands.get( 'highlight' );
-			dropdown = editor.ui.componentFactory.create( 'highlightDropdown' );
+			dropdown = editor.ui.componentFactory.create( 'highlight' );
 		} );
 
 		it( 'button has the base properties', () => {
@@ -223,7 +223,7 @@ describe( 'HighlightUI', () => {
 					} )
 					.then( newEditor => {
 						editor = newEditor;
-						dropdown = editor.ui.componentFactory.create( 'highlightDropdown' );
+						dropdown = editor.ui.componentFactory.create( 'highlight' );
 						command = editor.commands.get( 'highlight' );
 
 						editorElement.remove();

--- a/tests/manual/highlight.js
+++ b/tests/manual/highlight.js
@@ -13,7 +13,7 @@ ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [ ArticlePluginSet, Highlight ],
 		toolbar: [
-			'headings', '|', 'highlightDropdown', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
+			'heading', '|', 'highlightDropdown', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
 		]
 	} )
 	.then( editor => {

--- a/tests/manual/highlight.js
+++ b/tests/manual/highlight.js
@@ -13,7 +13,7 @@ ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [ ArticlePluginSet, Highlight ],
 		toolbar: [
-			'heading', '|', 'highlightDropdown', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
+			'heading', '|', 'highlight', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
 		]
 	} )
 	.then( editor => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Renamed 'highlightDropdown' to 'highlight'.

---

### Additional information

* PR of : https://github.com/ckeditor/ckeditor5-alignment/pull/25.
