### PR TITLE
Highlight works fine with the font size plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@ckeditor/ckeditor5-cloud-services": "^1.0.0-beta.2",
     "@ckeditor/ckeditor5-editor-classic": "^1.0.0-beta.2",
     "@ckeditor/ckeditor5-enter": "^1.0.0-beta.2",
+    "@ckeditor/ckeditor5-font": "^1.0.0-beta.2",
     "@ckeditor/ckeditor5-heading": "^1.0.0-beta.2",
     "@ckeditor/ckeditor5-image": "^1.0.0-beta.2",
     "@ckeditor/ckeditor5-list": "^1.0.0-beta.2",

--- a/src/highlightediting.js
+++ b/src/highlightediting.js
@@ -117,10 +117,6 @@ function _buildDowncastDefinition( options ) {
 		definition.model.values.push( option.model );
 
 		definition.view[ option.model ] = ( modelAttributeValue, viewWriter ) => {
-			if ( modelAttributeValue !== option.model ) {
-				return null;
-			}
-
 			const attributes = { class: option.class };
 
 			// Highlight element has to have higher priority than other view elements because it must sticks directly to the text.

--- a/src/highlightediting.js
+++ b/src/highlightediting.js
@@ -119,7 +119,7 @@ function _buildDowncastDefinition( options ) {
 		definition.view[ option.model ] = ( modelAttributeValue, viewWriter ) => {
 			const attributes = { class: option.class };
 
-			// Highlight element has to have higher priority than other view elements because it must sticks directly to the text.
+			// Highlight element has to have higher priority than other view elements because it must stick directly to the text.
 			// See: https://github.com/ckeditor/ckeditor5-highlight/issues/17.
 			const options = { priority: AttributeElement.DEFAULT_PRIORITY + 5 };
 

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -14,9 +14,11 @@ import ImageCaption from '@ckeditor/ckeditor5-image/src/imagecaption';
 import List from '@ckeditor/ckeditor5-list/src/list';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import Delete from '@ckeditor/ckeditor5-typing/src/delete';
+import FontSize from '@ckeditor/ckeditor5-font/src/fontsize';
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 
 describe( 'Highlight', () => {
 	let editor, model, element;
@@ -27,7 +29,7 @@ describe( 'Highlight', () => {
 
 		return ClassicTestEditor
 			.create( element, {
-				plugins: [ Highlight, BlockQuote, Paragraph, Heading, Image, ImageCaption, List, Enter, Delete ]
+				plugins: [ Highlight, BlockQuote, Paragraph, Heading, Image, ImageCaption, List, Enter, Delete, FontSize ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -63,6 +65,24 @@ describe( 'Highlight', () => {
 				'<paragraph>foo[<$text highlight="yellowMarker">foo</$text></paragraph>' +
 				'<image src="foo.png"><caption><$text highlight="yellowMarker">abc</$text></caption></image>' +
 				'<paragraph><$text highlight="yellowMarker">bar</$text>]bar</paragraph>'
+			);
+		} );
+	} );
+
+	describe( 'compatibility with font size', () => {
+		it( 'the view "mark" element should stick directly to the text', () => {
+			setModelData( model, '<paragraph>Foo [Bar] Baz.</paragraph>' );
+
+			editor.execute( 'highlight', { value: 'yellowMarker' } );
+
+			expect( getViewData( editor.editing.view ) ).to.equal(
+				'<p>Foo {<mark class="marker-yellow">Bar</mark>} Baz.</p>'
+			);
+
+			editor.execute( 'fontSize', { value: 'huge' } );
+
+			expect( getViewData( editor.editing.view ) ).to.equal(
+				'<p>Foo {<span class="text-huge"><mark class="marker-yellow">Bar</mark></span>} Baz.</p>'
 			);
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Highlight plugin will render the highlighted text properly when it's combined with the `FontSize` plugin. Closes #17.