### PR TITLE
t/ckeditor5/1348: Used the getViewportTopOffsetConfig helper in the code snippets.

### DIFF
--- a/docs/_snippets/features/custom-highlight-colors-inline.js
+++ b/docs/_snippets/features/custom-highlight-colors-inline.js
@@ -14,7 +14,7 @@ ClassicEditor
 			items: [
 				'heading', '|', 'bulletedList', 'numberedList', 'highlight', 'undo', 'redo'
 			],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		highlight: {
 			options: [

--- a/docs/_snippets/features/custom-highlight-colors-variables.js
+++ b/docs/_snippets/features/custom-highlight-colors-variables.js
@@ -14,7 +14,7 @@ ClassicEditor
 			items: [
 				'heading', '|', 'bulletedList', 'numberedList', 'highlight', 'undo', 'redo'
 			],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		highlight: {
 			options: [

--- a/docs/_snippets/features/custom-highlight-options.js
+++ b/docs/_snippets/features/custom-highlight-options.js
@@ -14,7 +14,7 @@ ClassicEditor
 			items: [
 				'heading', '|', 'bulletedList', 'numberedList', 'highlight', 'undo', 'redo'
 			],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		highlight: {
 			options: [

--- a/docs/_snippets/features/highlight-buttons.js
+++ b/docs/_snippets/features/highlight-buttons.js
@@ -15,7 +15,7 @@ ClassicEditor
 				'heading', '|', 'highlight:yellowMarker', 'highlight:greenMarker', 'highlight:pinkMarker',
 				'highlight:greenPen', 'highlight:redPen', 'removeHighlight', '|', 'undo', 'redo'
 			],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		}
 	} )
 	.then( editor => {

--- a/docs/_snippets/features/highlight.js
+++ b/docs/_snippets/features/highlight.js
@@ -14,7 +14,7 @@ ClassicEditor
 			items: [
 				'heading', '|', 'bulletedList', 'numberedList', 'highlight', 'undo', 'redo'
 			],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		}
 	} )
 	.then( editor => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Used the `getViewportTopOffsetConfig` helper in the code snippets to make sure the toolbar top offset is correct regardless of the page layout (see ckeditor/ckeditor5#1348).

---

### Additional information

This PR is a piece of the https://github.com/ckeditor/ckeditor5/pull/1360 constellation.
