### PR TITLE
i/5677: Highlight styles should be prefixed with the .ck-content class

### DIFF
--- a/theme/highlight.css
+++ b/theme/highlight.css
@@ -13,13 +13,13 @@
 }
 
 @define-mixin highlight-marker-color $color {
-	.marker-$color {
+	.ck-content .marker-$color {
 		background-color: var(--ck-highlight-marker-$color);
 	}
 }
 
 @define-mixin highlight-pen-color $color {
-	.pen-$color {
+	.ck-content .pen-$color {
 		color: var(--ck-highlight-pen-$color);
 
 		/* Override default yellow background of `<mark>` from user agent stylesheet */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Highlight styles should be prefixed with the .ck-content class. Closes ckeditor/ckeditor5#5677.

---

### Additional information

Should be followed by https://github.com/ckeditor/ckeditor5/pull/5679.
